### PR TITLE
Add support for fractional seconds and formatting years with "yy" and "yyy" options

### DIFF
--- a/src/commonMain/kotlin/com/soywiz/klock/SimplerDateFormat.kt
+++ b/src/commonMain/kotlin/com/soywiz/klock/SimplerDateFormat.kt
@@ -72,7 +72,10 @@ class SimplerDateFormat(val format: String) {
 				"MMM" -> englishMonths[dd.month0].substr(0, 3).capitalize()
 				"MMMM" -> englishMonths[dd.month0].capitalize()
 				"MMMMM" -> englishMonths[dd.month0].substr(0, 1).capitalize()
-				"y","yyyy" -> dd.year.padded(4)
+				"y", -> dd.year
+				"yy" -> (dd.year % 100).padded(2)
+				"yyy" -> (dd.year % 1000).padded(3)
+				"yyyy" -> dd.year.padded(4)
 				"YYYY" -> dd.year.padded(4)
 				"H" -> dd.hours.padded(1)
 				"HH" -> dd.hours.padded(2)
@@ -147,6 +150,8 @@ class SimplerDateFormat(val format: String) {
 				"M", "MM" -> month = value.toInt()
 				"MMM" -> month = englishMonths3.indexOf(value.toLowerCase()) + 1
 				"y", "yyyy", "YYYY" -> fullYear = value.toInt()
+				"yy" -> throw RuntimeException("Not guessing years from two digits.")
+				"yyy" -> fullYear = value.toInt() + if (value.toInt() < 800) 2000 else 1000 // guessing year...
 				"H", "HH" -> hour = value.toInt()
 				"m", "mm" -> minute = value.toInt()
 				"s", "ss" -> second = value.toInt()

--- a/src/commonMain/kotlin/com/soywiz/klock/SimplerDateFormat.kt
+++ b/src/commonMain/kotlin/com/soywiz/klock/SimplerDateFormat.kt
@@ -72,7 +72,7 @@ class SimplerDateFormat(val format: String) {
 				"MMM" -> englishMonths[dd.month0].substr(0, 3).capitalize()
 				"MMMM" -> englishMonths[dd.month0].capitalize()
 				"MMMMM" -> englishMonths[dd.month0].substr(0, 1).capitalize()
-				"y", -> dd.year
+				"y" -> dd.year
 				"yy" -> (dd.year % 100).padded(2)
 				"yyy" -> (dd.year % 1000).padded(3)
 				"yyyy" -> dd.year.padded(4)

--- a/src/commonMain/kotlin/com/soywiz/klock/SimplerDateFormat.kt
+++ b/src/commonMain/kotlin/com/soywiz/klock/SimplerDateFormat.kt
@@ -44,7 +44,7 @@ class SimplerDateFormat(val format: String) {
 		} else if (v.startsWith("X", ignoreCase = true)) {
 			"""([Z]|[+-]\d\d|[+-]\d\d\d\d|[+-]\d\d:\d\d)?"""
 		} else {
-			"""([\w\+\-]*[^Z+-])"""
+			"""([\w\+\-]*[^Z+-\.])"""
 		}
 	} + "$")
 

--- a/src/commonMain/kotlin/com/soywiz/klock/SimplerDateFormat.kt
+++ b/src/commonMain/kotlin/com/soywiz/klock/SimplerDateFormat.kt
@@ -2,7 +2,7 @@ package com.soywiz.klock
 
 class SimplerDateFormat(val format: String) {
 	companion object {
-		private val rx = Regex("('[\\w]+'|[\\w]+\\B[^Xx]|[Xx]{1,3}|[\\w]+)")
+		private val rx = Regex("""('[\w]+'|[\w]+\B[^Xx]|[Xx]{1,3}|[\w]+)""")
 		private val englishDaysOfWeek = listOf(
 			"sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"
 		)
@@ -40,9 +40,9 @@ class SimplerDateFormat(val format: String) {
 		if (v.startsWith("'")) {
 			"(" + Regex.escapeReplacement(v.trim('\'')) + ")"
 		} else if (v.startsWith("X", ignoreCase = true)) {
-			"([Z]|[+-]\\d\\d|[+-]\\d\\d\\d\\d|[+-]\\d\\d:\\d\\d)?"
+			"""([Z]|[+-]\d\d|[+-]\d\d\d\d|[+-]\d\d:\d\d)?"""
 		} else {
-			"([\\w\\+\\-]*[^Z+-])"
+			"""([\w\+\-]*[^Z+-])"""
 		}
 	} + "$")
 

--- a/src/commonTest/kotlin/com/soywiz/klock/DateTimeTest.kt
+++ b/src/commonTest/kotlin/com/soywiz/klock/DateTimeTest.kt
@@ -27,7 +27,11 @@ class DateTimeTest {
 		assertEquals("Sat, 08 S 2018 04:08:09 UTC", SimplerDateFormat("EEE, dd MMMMM yyyy HH:mm:ss z").format(dt).toString())
 
 		assertEquals("Sat, 08 Sep 2018 04:08:09 UTC", SimplerDateFormat("EEE, dd MMM y HH:mm:ss z").format(dt).toString())
-		assertEquals("Sat, 08 Sep 2018 04:08:09 UTC", SimplerDateFormat("EEE, dd MMM YYYY HH:mm:ss z").format(dt).toString())
+        assertEquals("Sat, 08 Sep 18 04:08:09 UTC", SimplerDateFormat("EEE, dd MMM yy HH:mm:ss z").format(dt).toString())
+        assertEquals("Sat, 08 Sep 018 04:08:09 UTC", SimplerDateFormat("EEE, dd MMM yyy HH:mm:ss z").format(dt).toString())
+        assertEquals("Sat, 08 Sep 2018 04:08:09 UTC", SimplerDateFormat("EEE, dd MMM yyyy HH:mm:ss z").format(dt).toString())
+
+        assertEquals("Sat, 08 Sep 2018 04:08:09 UTC", SimplerDateFormat("EEE, dd MMM YYYY HH:mm:ss z").format(dt).toString())
 
 		assertEquals("Sat, 08 Sep 2018 4:08:09 UTC", SimplerDateFormat("EEE, dd MMM yyyy H:mm:ss z").format(dt).toString())
 
@@ -98,6 +102,14 @@ class DateTimeTest {
         assertEquals(message = "Sat, 08 Sep 2018 04:08:09 UTC - y",
                 expected = dtmilli,
                 actual = SimplerDateFormat("EEE, dd MMM y HH:mm:ss z").parse("Sat, 08 Sep 2018 04:08:09 UTC"))
+        assertEquals(message = "Sat, 08 Sep 18 04:08:09 UTC - yy",
+                expected = null,
+                actual = SimplerDateFormat("EEE, dd MMM yy HH:mm:ss z").parseOrNull("Sat, 08 Sep 18 04:08:09 UTC"))
+        assertEquals(message = "Sat, 08 Sep 018 04:08:09 UTC - yyy",
+                expected = dtmilli,
+                actual = SimplerDateFormat("EEE, dd MMM yyy HH:mm:ss z").parse("Sat, 08 Sep 018 04:08:09 UTC"))
+
+
         assertEquals(message = "Sat, 08 Sep 2018 04:08:09 UTC - YYYY",
                 expected = dtmilli,
                 actual = SimplerDateFormat("EEE, dd MMM YYYY HH:mm:ss z").parse("Sat, 08 Sep 2018 04:08:09 UTC"))

--- a/src/commonTest/kotlin/com/soywiz/klock/DateTimeTest.kt
+++ b/src/commonTest/kotlin/com/soywiz/klock/DateTimeTest.kt
@@ -39,8 +39,29 @@ class DateTimeTest {
 		assertEquals("Sat, 08 Sep 2018 04:08:9 UTC", SimplerDateFormat("EEE, dd MMM yyyy HH:mm:s z").format(dt).toString())
 	}
 
+    @Test
+    fun testFormattingToCustomDateTimeFormatsWithMilliseconds999(){
+        val dt = DateTime(2018, 9, 8, 4, 8, 9, 999)
+        assertEquals("Sat, 08 Sep 2018 04:08:9.9 UTC", SimplerDateFormat("EEE, dd MMM yyyy HH:mm:s.S z").format(dt).toString())
+        assertEquals("Sat, 08 Sep 2018 04:08:9.99 UTC", SimplerDateFormat("EEE, dd MMM yyyy HH:mm:s.SS z").format(dt).toString())
+        assertEquals("Sat, 08 Sep 2018 04:08:9.999 UTC", SimplerDateFormat("EEE, dd MMM yyyy HH:mm:s.SSS z").format(dt).toString())
+        assertEquals("Sat, 08 Sep 2018 04:08:9.9990 UTC", SimplerDateFormat("EEE, dd MMM yyyy HH:mm:s.SSSS z").format(dt).toString())
+        assertEquals("Sat, 08 Sep 2018 04:08:9.99900 UTC", SimplerDateFormat("EEE, dd MMM yyyy HH:mm:s.SSSSS z").format(dt).toString())
+        assertEquals("Sat, 08 Sep 2018 04:08:9.999000 UTC", SimplerDateFormat("EEE, dd MMM yyyy HH:mm:s.SSSSSS z").format(dt).toString())
+    }
+
+    @Test
+    fun testFormattingToCustomDateTimeFormatsWithMilliseconds009(){
+        val dt = DateTime(2018, 9, 8, 4, 8, 9, 9)
+        assertEquals("Sat, 08 Sep 2018 04:08:9.0 UTC", SimplerDateFormat("EEE, dd MMM yyyy HH:mm:s.S z").format(dt).toString())
+        assertEquals("Sat, 08 Sep 2018 04:08:9.00 UTC", SimplerDateFormat("EEE, dd MMM yyyy HH:mm:s.SS z").format(dt).toString())
+        assertEquals("Sat, 08 Sep 2018 04:08:9.009 UTC", SimplerDateFormat("EEE, dd MMM yyyy HH:mm:s.SSS z").format(dt).toString())
+        assertEquals("Sat, 08 Sep 2018 04:08:9.0090 UTC", SimplerDateFormat("EEE, dd MMM yyyy HH:mm:s.SSSS z").format(dt).toString())
+        assertEquals("Sat, 08 Sep 2018 04:08:9.00900 UTC", SimplerDateFormat("EEE, dd MMM yyyy HH:mm:s.SSSSS z").format(dt).toString())
+        assertEquals("Sat, 08 Sep 2018 04:08:9.009000 UTC", SimplerDateFormat("EEE, dd MMM yyyy HH:mm:s.SSSSSS z").format(dt).toString())
+    }
+
 	@Test
-	@Ignore // TEMPORAL IGNORE
 	fun testParsingDateTimesInCustomStringFormats(){
 		val dtmilli = 1536379689000L
 		assertEquals(dtmilli, DateTime(2018, 9, 8, 4, 8, 9).unix)
@@ -95,7 +116,6 @@ class DateTimeTest {
 	}
 
     @Test
-	@Ignore // TEMPORAL IGNORE
     fun testParsingDateTimesInCustomStringFormatsWithAmPm() {
         val amDtmilli = 1536379689000L
         assertEquals(amDtmilli, DateTime(2018, 9, 8, 4, 8, 9).unix)
@@ -130,6 +150,49 @@ class DateTimeTest {
                 expected = pmDtmilli,
                 actual = SimplerDateFormat("EEE, dd MMM yyyy HH:mm:ss a z").parse("Sat, 08 Sep 2018 16:08:09 pm UTC"))
     }
+
+    @Test
+    fun testParsingDateTimesWithDeciSeconds() {
+        var dtmilli = 1536379689009L
+        assertEquals(dtmilli, DateTime(2018, 9, 8, 4, 8, 9, 9).unix)
+        assertEquals(message = "Sat, 08 Sep 2018 04:08:09.9 UTC",
+                expected = dtmilli,
+                actual = SimplerDateFormat("EEE, dd MMM yyyy HH:mm:ss.S z").parse("Sat, 08 Sep 2018 04:08:09.9 UTC"))
+    }
+
+    @Test
+    fun testParsingDateTimesWithCentiSeconds() {
+        var dtmilli = 1536379689099L
+        assertEquals(dtmilli, DateTime(2018, 9, 8, 4, 8, 9, 99).unix)
+        assertEquals(message = "Sat, 08 Sep 2018 04:08:09.99 UTC",
+                expected = dtmilli,
+                actual = SimplerDateFormat("EEE, dd MMM yyyy HH:mm:ss.SS z").parse("Sat, 08 Sep 2018 04:08:09.99 UTC"))
+    }
+
+    @Test
+    fun testParsingDateTimesWithMilliseconds() {
+        var dtmilli = 1536379689999L
+        assertEquals(dtmilli, DateTime(2018, 9, 8, 4, 8, 9, 999).unix)
+        assertEquals(message = "Sat, 08 Sep 2018 04:08:09.999 UTC",
+                expected = dtmilli,
+                actual = SimplerDateFormat("EEE, dd MMM yyyy HH:mm:ss.SSS z").parse("Sat, 08 Sep 2018 04:08:09.999 UTC"))
+    }
+
+    @Test
+    fun testParsingDateTimesWithGreaterPrecisionThanMillisecond() {
+        val dtmilli = 1536379689999L
+        assertEquals(dtmilli, DateTime(2018, 9, 8, 4, 8, 9, 999).unix)
+        assertEquals(message = "Sat, 08 Sep 2018 04:08:09.9999 UTC",
+                expected = dtmilli,
+                actual = SimplerDateFormat("EEE, dd MMM yyyy HH:mm:ss.SSSS z").parse("Sat, 08 Sep 2018 04:08:09.9999 UTC"))
+        assertEquals(message = "Sat, 08 Sep 2018 04:08:09.99999 UTC",
+                expected = dtmilli,
+                actual = SimplerDateFormat("EEE, dd MMM yyyy HH:mm:ss.SSSSS z").parse("Sat, 08 Sep 2018 04:08:09.99999 UTC"))
+        assertEquals(message = "Sat, 08 Sep 2018 04:08:09.999999 UTC",
+                expected = dtmilli,
+                actual = SimplerDateFormat("EEE, dd MMM yyyy HH:mm:ss.SSSSSS z").parse("Sat, 08 Sep 2018 04:08:09.999999 UTC"))
+    }
+
 
 	@Test
 	fun testParse() {


### PR DESCRIPTION
also converted regex expressions to use raw strings because it is easier to read (in my opinion)