### PR TITLE
Update to Kotlin 1.3.20 and Gradle 5.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 }
 
 plugins {
-    id 'kotlin-multiplatform' version '1.3.11'
+    id 'kotlin-multiplatform' version '1.3.20'
     id 'com.moowork.node' version '1.2.0'
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
1.3.20 is stable and all of the kotlinx libs have been updated to publish with gradle metadata 0.4