### PR TITLE
Fix android publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,9 @@ repositories {
 kotlin {
     targets {
         if (hasAndroid) {
-            fromPreset(presets.android, 'android')
+            fromPreset(presets.android, 'android') {
+                publishLibraryVariants("release", "debug")
+            }
         }
         fromPreset(presets.iosX64, 'iosX64')
         fromPreset(presets.iosArm32, 'iosArm32')


### PR DESCRIPTION
Android artifacts are not published unless variant names are provided. See [Publishing Android Libraries](https://kotlinlang.org/docs/reference/building-mpp-with-gradle.html#publishing-android-libraries)