### PR TITLE
Format offsets using absolute value in PatternDateFormat

### DIFF
--- a/klock/src/commonMain/kotlin/com/soywiz/klock/PatternDateFormat.kt
+++ b/klock/src/commonMain/kotlin/com/soywiz/klock/PatternDateFormat.kt
@@ -84,8 +84,8 @@ class PatternDateFormat(val format: String) : DateFormat {
                         name.startsWith("X") && dd.offset.totalMinutesInt == 0 -> "Z"
                         else -> {
                             val p = if (dd.offset.totalMinutesInt >= 0) "+" else "-"
-                            val hours = dd.offset.totalMinutesInt / 60
-                            val minutes = dd.offset.totalMinutesInt % 60
+                            val hours = (dd.offset.totalMinutesInt / 60).absoluteValue
+                            val minutes = (dd.offset.totalMinutesInt % 60).absoluteValue
                             when (name) {
                                 "X", "x" -> "$p${hours.padded(2)}"
                                 "XX", "xx" -> "$p${hours.padded(2)}${minutes.padded(2)}"

--- a/klock/src/commonTest/kotlin/com/soywiz/klock/SimplerDateFormatTest.kt
+++ b/klock/src/commonTest/kotlin/com/soywiz/klock/SimplerDateFormatTest.kt
@@ -36,6 +36,22 @@ class SimplerDateFormatTest {
         }
 
         @Test
+        fun testFormatWithNegativeOffset() {
+            val now = DateTime.fromUnix(1462390174000)
+                .toOffsetUnadjusted((-3.5).hours)
+            val formatted = now.format(format)
+            assertEquals("2016-05-04T19:29:34-03:30", formatted)
+        }
+
+        @Test
+        fun testFormatWithPositiveOffset() {
+            val now = DateTime.fromUnix(1462390174000)
+                .toOffsetUnadjusted(4.5.hours)
+            val formatted = now.format(format)
+            assertEquals("2016-05-04T19:29:34+04:30", formatted)
+        }
+
+        @Test
         fun testParseFormatUtc() {
             val dateStr = "2016-05-04T19:29:34+00:00"
             assertEquals(dateStr, format.format(format.parseDouble(dateStr)))


### PR DESCRIPTION
Fixes negative offsets formatting as `2016-05-04T19:29:34-3:-30`