### PR TITLE
Allow nullable result type in measureTimeWithResult

### DIFF
--- a/klock/src/commonMain/kotlin/com/soywiz/klock/Measure.kt
+++ b/klock/src/commonMain/kotlin/com/soywiz/klock/Measure.kt
@@ -14,11 +14,11 @@ inline fun measureTime(callback: () -> Unit): TimeSpan {
  * Executes a [callback] measuring the time it takes to complete,
  * returning a [TimedResult] with the time and the returning value of the callback.
  */
-inline fun <T : Any> measureTimeWithResult(callback: () -> T): TimedResult<T> {
-    lateinit var result: T
-    val elapsed = measureTime {
-        result = callback()
-    }
+inline fun <T> measureTimeWithResult(callback: () -> T): TimedResult<T> {
+    val start = PerformanceCounter.microseconds
+    val result = callback()
+    val end = PerformanceCounter.microseconds
+    val elapsed = (end - start).microseconds
     return TimedResult(result, elapsed)
 }
 


### PR DESCRIPTION
Change `T: Any` to just `T` to allow nullable result of `callback: () -> T`. Implementation taken from `measureTime` function (with minor change of saving the result of callback), since it is forbidden to make `lateinit var` of nullable type.