### PR TITLE
Updates for Time

### DIFF
--- a/klock/src/commonMain/kotlin/com/soywiz/klock/DateFormat.kt
+++ b/klock/src/commonMain/kotlin/com/soywiz/klock/DateFormat.kt
@@ -1,6 +1,6 @@
 package com.soywiz.klock
 
-/** Allows to [format] and [parse] instances of [DateTime] and [DateTimeTz] */
+/** Allows to [format] and [parse] instances of [Date], [DateTime] and [DateTimeTz] */
 interface DateFormat {
     fun format(dd: DateTimeTz): String
     fun tryParse(str: String, doThrow: Boolean = false): DateTimeTz?
@@ -30,6 +30,7 @@ interface DateFormat {
 
 fun DateFormat.parse(str: String): DateTimeTz =
     tryParse(str, doThrow = true) ?: throw DateException("Not a valid format: '$str' for '$this'")
+fun DateFormat.parseDate(str: String): Date = parse(str).local.date
 
 fun DateFormat.parseUtc(str: String): DateTime = parse(str).utc
 

--- a/klock/src/commonMain/kotlin/com/soywiz/klock/PatternTimeFormat.kt
+++ b/klock/src/commonMain/kotlin/com/soywiz/klock/PatternTimeFormat.kt
@@ -1,0 +1,176 @@
+package com.soywiz.klock
+
+import com.soywiz.klock.internal.*
+import com.soywiz.klock.internal.MicroStrReader
+import com.soywiz.klock.internal.increment
+import com.soywiz.klock.internal.padded
+import com.soywiz.klock.internal.substr
+import kotlin.math.log10
+import kotlin.math.pow
+
+data class PatternTimeFormat(
+    val format: String,
+    val options: Options = Options.DEFAULT
+) : TimeFormat {
+
+    data class Options(val optionalSupport: Boolean = false) {
+        companion object {
+            val DEFAULT = Options(optionalSupport = false)
+            val WITH_OPTIONAL = Options(optionalSupport = true)
+        }
+    }
+
+    fun withOptions(options: Options) = this.copy(options = options)
+    fun withOptional() = this.copy(options = options.copy(optionalSupport = true))
+    fun withNonOptional() = this.copy(options = options.copy(optionalSupport = false))
+
+    private val openOffsets = LinkedHashMap<Int, Int>()
+    private val closeOffsets = LinkedHashMap<Int, Int>()
+
+    internal val chunks = arrayListOf<String>().also { chunks ->
+        val s = MicroStrReader(format)
+        while (s.hasMore) {
+            if (s.peekChar() == '\'') {
+                val escapedChunk = s.readChunk {
+                    s.tryRead('\'')
+                    while (s.hasMore && s.readChar() != '\'') Unit
+                }
+                chunks.add(escapedChunk)
+                continue
+            }
+            if (options.optionalSupport) {
+                val offset = chunks.size
+                if (s.tryRead('[')) {
+                    openOffsets.increment(offset)
+                    continue
+                }
+                if (s.tryRead(']')) {
+                    closeOffsets.increment(offset - 1)
+                    continue
+                }
+            }
+            val chunk = s.readChunk {
+                val c = s.readChar()
+                while (s.hasMore && s.tryRead(c)) Unit
+            }
+            chunks.add(chunk)
+        }
+    }.toList()
+
+    private val regexChunks = chunks.map {
+        when (it) {
+            "H", "k" -> """(\d{1,})"""
+            "HH", "kk" -> """(\d{2,})"""
+            "h", "K" -> """(\d{1,2})"""
+            "hh", "KK" -> """(\d{2})"""
+            "m" -> """(\d{1,2})"""
+            "mm" -> """(\d{2})"""
+            "s" -> """(\d{1,2})"""
+            "ss" -> """(\d{2})"""
+            "S" -> """(\d{1,6})"""
+            "SS" -> """(\d{2})"""
+            "SSS" -> """(\d{3})"""
+            "SSSS" -> """(\d{4})"""
+            "SSSSS" -> """(\d{5})"""
+            "SSSSSS" -> """(\d{6})"""
+            "SSSSSSS" -> """(\d{7})"""
+            "SSSSSSSS" -> """(\d{8})"""
+            "a" -> """(\w+)"""
+            " " -> """(\s+)"""
+            else -> when {
+                it.startsWith('\'') -> "(" + Regex.escapeReplacement(it.substr(1, it.length - 2)) + ")"
+                else -> "(" + Regex.escapeReplacement(it) + ")"
+            }
+        }
+    }
+
+    private val rx2: Regex = Regex("^" + regexChunks.mapIndexed { index, it ->
+        if (options.optionalSupport) {
+            val opens = openOffsets.getOrElse(index) { 0 }
+            val closes = closeOffsets.getOrElse(index) { 0 }
+            buildString {
+                repeat(opens) { append("(?:") }
+                append(it)
+                repeat(closes) { append(")?") }
+            }
+        } else {
+            it
+        }
+    }.joinToString("") + "$")
+
+    private fun clampZero(value: Int, size: Int) = (value umod size)
+
+    private fun clampNonZero(value: Int, size: Int) = (value umod size).let { if (it == 0) size else it }
+
+    override fun format(dd: TimeSpan): String {
+        val time = Time(dd)
+        var out = ""
+        for (name in chunks) {
+            val nlen = name.length
+            out += when (name) {
+                "H", "HH" -> time.hour.padded(nlen)
+                "k", "kk" -> time.hour.padded(nlen)
+
+                "h", "hh" -> clampNonZero(time.hour, 12).padded(nlen)
+                "K", "KK" -> clampZero(time.hour, 12).padded(nlen)
+
+                "m", "mm" -> time.minute.padded(nlen)
+                "s", "ss" -> time.second.padded(nlen)
+
+                "S", "SS", "SSS", "SSSS", "SSSSS", "SSSSSS", "SSSSSSS", "SSSSSSSS" -> {
+                    val milli = time.millisecond
+                    val numberLength = log10(time.millisecond.toDouble()).toInt() + 1
+                    if (numberLength > name.length) {
+                        (milli.toDouble() / 10.0.pow(numberLength - name.length)).toInt()
+                    } else {
+                        "${milli.padded(3)}00000".substr(0, name.length)
+                    }
+                }
+                "a" -> if (time.hour < 12) "am" else if (time.hour < 24) "pm" else ""
+                else -> if (name.startsWith('\'')) name.substring(1, name.length - 1) else name
+            }
+        }
+        return out
+    }
+
+    override fun tryParse(str: String, doThrow: Boolean): TimeSpan? {
+        var millisecond = 0
+        var second = 0
+        var minute = 0
+        var hour = 0
+        var isPm = false
+        var is12HourFormat = false
+        val result = rx2.find(str) ?: return null //println("Parser error: Not match, $str, $rx2");
+        for ((name, value) in chunks.zip(result.groupValues.drop(1))) {
+            if (value.isEmpty()) continue
+            when (name) {
+                "H", "HH", "k", "kk" -> hour = value.toInt()
+                "h", "hh", "K", "KK" -> {
+                    hour = value.toInt() umod 24
+                    is12HourFormat = true
+                }
+                "m", "mm" -> minute = value.toInt()
+                "s", "ss" -> second = value.toInt()
+                "S", "SS", "SSS", "SSSS", "SSSSS", "SSSSSS" -> {
+                    val numberLength = log10(value.toDouble()).toInt() + 1
+                    millisecond = if (numberLength > 3) {
+                        // only precision to millisecond supported, ignore the rest: 9999999 => 999
+                        (value.toDouble() * 10.0.pow(-1 * (numberLength - 3))).toInt()
+                    } else {
+                        value.toInt()
+                    }
+                }
+                "a" -> isPm = value == "pm"
+                else -> {
+                    // ...
+                }
+            }
+        }
+        if (is12HourFormat && isPm) {
+            hour += 12
+        }
+        return hour.hours + minute.minutes + second.seconds + millisecond.milliseconds
+    }
+
+    override fun toString(): String = format
+}

--- a/klock/src/commonMain/kotlin/com/soywiz/klock/Time.kt
+++ b/klock/src/commonMain/kotlin/com/soywiz/klock/Time.kt
@@ -24,6 +24,16 @@ inline class Time(val encoded: TimeSpan) : Comparable<Time> {
 	val minute: Int get() = abs((encoded.millisecondsInt / DIV_MINUTES) % 60)
     /** The [hour] part. */
 	val hour: Int get() = (encoded.millisecondsInt / DIV_HOURS)
+    /** The [hour] part adjusted to 24-hour format. */
+	val hourAdjusted: Int get() = (encoded.millisecondsInt / DIV_HOURS % 24)
+
+    /** Returns new [Time] instance adjusted to 24-hour format. */
+    fun adjust(): Time = Time(hourAdjusted, minute, second, millisecond)
+
+    /** Converts this date to String using [format] for representing it. */
+    fun format(format: String) = TimeFormat(format).format(this)
+    /** Converts this date to String using [format] for representing it. */
+    fun format(format: TimeFormat) = format.format(this)
 
     /** Converts this time to String formatting it like "00:00:00.000", "23:59:59.999" or "-23:59:59.999" if the [hour] is negative */
 	override fun toString(): String = "${if (hour < 0) "-" else ""}${abs(hour).toString().padStart(2, '0')}:${abs(minute).toString().padStart(2, '0')}:${abs(second).toString().padStart(2, '0')}.${abs(millisecond).toString().padStart(3, '0')}"
@@ -31,5 +41,4 @@ inline class Time(val encoded: TimeSpan) : Comparable<Time> {
 	override fun compareTo(other: Time): Int = encoded.compareTo(other.encoded)
 }
 
-// @TODO: Do overflowing here instead of relying on DateTime. In fact, refact DateTime to handle the overflowing using this class
-operator fun Time.plus(span: TimeSpan) = (DateTime.EPOCH + this.encoded + span).time
+operator fun Time.plus(span: TimeSpan) = Time(this.encoded + span)

--- a/klock/src/commonMain/kotlin/com/soywiz/klock/TimeFormat.kt
+++ b/klock/src/commonMain/kotlin/com/soywiz/klock/TimeFormat.kt
@@ -3,7 +3,34 @@ package com.soywiz.klock
 interface TimeFormat {
     fun format(dd: TimeSpan): String
     fun tryParse(str: String, doThrow: Boolean): TimeSpan?
+
+    companion object {
+        val DEFAULT_FORMAT = TimeFormat("HH:mm:ss.SSS")
+        val FORMAT_TIME = TimeFormat("HH:mm:ss")
+
+        val FORMATS = listOf(DEFAULT_FORMAT, FORMAT_TIME)
+
+        fun parse(time: String): TimeSpan {
+            var lastError: Throwable? = null
+            for (format in FORMATS) {
+                try {
+                    return format.parse(time)
+                } catch (e: Throwable) {
+                    lastError = e
+                }
+            }
+            throw lastError!!
+        }
+
+        operator fun invoke(pattern: String) = PatternTimeFormat(pattern)
+    }
 }
 
 fun TimeFormat.parse(str: String): TimeSpan =
     tryParse(str, doThrow = true) ?: throw DateException("Not a valid format: '$str' for '$this'")
+fun TimeFormat.parseTime(str: String): Time = Time(parse(str))
+
+fun TimeFormat.format(time: Double): String = format(time.milliseconds)
+fun TimeFormat.format(time: Long): String = format(time.milliseconds)
+fun TimeFormat.format(time: Time): String = format(time.encoded)
+

--- a/klock/src/commonTest/kotlin/com/soywiz/klock/TimeFormatTest.kt
+++ b/klock/src/commonTest/kotlin/com/soywiz/klock/TimeFormatTest.kt
@@ -1,0 +1,56 @@
+package com.soywiz.klock
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TimeFormatTest {
+
+    @Test
+    fun testFormat() {
+        val time1 = Time(hour = 48, minute = 23, second = 12, millisecond = 450)
+        assertEquals("48:23:12.450", TimeFormat.DEFAULT_FORMAT.format(time1))
+        assertEquals("48:23:12", TimeFormat.FORMAT_TIME.format(time1))
+        assertEquals("48.23.12", TimeFormat("HH.mm.ss").format(time1))
+        assertEquals("12:23:12", TimeFormat("hh:mm:ss").format(time1))
+        assertEquals("48:23:12", TimeFormat("kk:mm:ss").format(time1))
+        assertEquals("00:23:12", TimeFormat("KK:mm:ss").format(time1))
+
+        val time2 = Time(hour = 50, minute = 2, second = 0, millisecond = 109)
+        assertEquals("2:2:0.10", TimeFormat("h:m:s.SS").format(time2))
+        assertEquals("2:2:0.1", TimeFormat("h:m:s.S").format(time2))
+        assertEquals("2:2:0", TimeFormat("K:m:s").format(time2))
+    }
+
+    @Test
+    fun testParse() {
+        val time1 = TimeFormat.FORMAT_TIME.parseTime("23:59:59")
+        assertEquals(23, time1.hour)
+        assertEquals(59, time1.minute)
+        assertEquals(59, time1.second)
+        assertEquals(0, time1.millisecond)
+
+        val time2 = TimeFormat.FORMAT_TIME.parseTime("48:00:00")
+        assertEquals(48, time2.hour)
+        assertEquals(0, time2.minute)
+        assertEquals(0, time2.second)
+        assertEquals(0, time2.millisecond)
+
+        val time3 = TimeFormat.DEFAULT_FORMAT.parseTime("23:59:59.999")
+        assertEquals(23, time3.hour)
+        assertEquals(59, time3.minute)
+        assertEquals(59, time3.second)
+        assertEquals(999, time3.millisecond)
+
+        val time4 = TimeFormat.DEFAULT_FORMAT.parseTime("48:00:00.000")
+        assertEquals(48, time4.hour)
+        assertEquals(0, time4.minute)
+        assertEquals(0, time4.second)
+        assertEquals(0, time4.millisecond)
+
+        val time = TimeFormat("ss.mm.HH").parseTime("59.59.48")
+        assertEquals(48, time.hour)
+        assertEquals(59, time.minute)
+        assertEquals(59, time.second)
+        assertEquals(0, time.millisecond)
+    }
+}

--- a/klock/src/commonTest/kotlin/com/soywiz/klock/TimeTest.kt
+++ b/klock/src/commonTest/kotlin/com/soywiz/klock/TimeTest.kt
@@ -4,8 +4,42 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class TimeTest {
-	@Test
-	fun test() {
-		assertEquals("09:30:00.000", (Time(9) + 30.minutes).toString())
-	}
+
+    @Test
+    fun test() {
+        assertEquals("09:30:00.000", (Time(9) + 30.minutes).toString())
+        assertEquals("26:00:00.000", (Time(26)).toString())
+        assertEquals("26:00:30.256", (Time(26) + 30.seconds + 256.milliseconds).toString())
+        assertEquals("16:00:30.256", (Time(16) + 30.seconds + 256.milliseconds).toString())
+    }
+
+    @Test
+    fun testProperties() {
+        val time = Time(hour = 12, minute = 36, second = 28, millisecond = 128)
+        assertEquals(12, time.hour)
+        assertEquals(36, time.minute)
+        assertEquals(28, time.second)
+        assertEquals(128, time.millisecond)
+
+        assertEquals(25, Time(25).hour)
+        assertEquals(36, Time(36).hour)
+        assertEquals(12, Time(36).hourAdjusted)
+    }
+
+    @Test
+    fun testAdjusting() {
+        val time = Time(hour = 25, minute = 62, second = 70, millisecond = 2000)
+        assertEquals(0, time.millisecond)
+        assertEquals(12, time.second)
+        assertEquals(3, time.minute)
+        assertEquals(26, time.hour)
+        assertEquals(2, time.hourAdjusted)
+
+        val timeAdjusted = time.adjust()
+        assertEquals(0, timeAdjusted.millisecond)
+        assertEquals(12, timeAdjusted.second)
+        assertEquals(3, timeAdjusted.minute)
+        assertEquals(2, timeAdjusted.hour)
+        assertEquals(2, timeAdjusted.hourAdjusted)
+    }
 }


### PR DESCRIPTION
Add a few updates:
- Add `hourAdjusted` property to Time returning hour number adjusted to 24-hour format.
- Add `adjust()` method to Time returning a new Time instance with adjusted hours.
- Add `format(String/TimeFormat)` method to Time converting this Time instance to String using specified string or format. Fix #90.
- Fix `Time.plus(TimeSpan)` function, now it uses TimeSpan instead of DateTime.
- Upgrade `TimeFormat`, now it includes two commonly used formats, can parse String to Time and can format Time, Int and Double as time sources.
- Add `PatternTimeFormat` class - a simplified version of `PatternDateFormat`, that can format and parse only hours, minutes, seconds and milliseconds without adjusting a large number of hours to 24-hour format.
- Add `parseDate(String)` function to DateFormat that lets you parse String to Date instance (not only DateTime as before).
- Also add tests for Time and TimeFormat classes in order to check their behavior.