### PR TITLE
Fixes #108 Added experimental wrapped variants of all the inline classes

### DIFF
--- a/klock/src/commonMain/kotlin/com/soywiz/klock/annotations/KlockExperimental.kt
+++ b/klock/src/commonMain/kotlin/com/soywiz/klock/annotations/KlockExperimental.kt
@@ -1,0 +1,4 @@
+package com.soywiz.klock.annotations
+
+@RequiresOptIn("Experimental API", RequiresOptIn.Level.WARNING)
+annotation class KlockExperimental

--- a/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WDate.kt
+++ b/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WDate.kt
@@ -1,0 +1,66 @@
+package com.soywiz.klock.wrapped
+
+import com.soywiz.klock.*
+import com.soywiz.klock.annotations.*
+
+@KlockExperimental
+val Date.wrapped get() = WDate(this)
+
+/**
+ * Wrapped Version, that is not inline. You can use [value] to get the wrapped inline class.
+ *
+ * Represents a triple of [year], [month] and [day].
+ *
+ * It is packed in an inline class wrapping an Int to prevent allocations.
+ */
+@KlockExperimental
+class WDate(val value: Date) : Comparable<WDate> {
+    companion object {
+        /** Constructs a new [WDate] from the [year], [month] and [day] components. */
+        operator fun invoke(year: Int, month: Int, day: Int) = Date(year, month, day).wrapped
+        /** Constructs a new [WDate] from the [year], [month] and [day] components. */
+        operator fun invoke(year: Int, month: WMonth, day: Int) = Date(year, month, day).wrapped
+        /** Constructs a new [WDate] from the [year], [month] and [day] components. */
+        operator fun invoke(year: WYear, month: WMonth, day: Int) = Date(year.value, month, day).wrapped
+        /** Constructs a new [WDate] from the [yearMonth] and [day] components. */
+        operator fun invoke(yearMonth: WYearMonth, day: Int) = Date(yearMonth.value, day).wrapped
+    }
+
+    /** The [year] part as [Int]. */
+    val year: Int get() = value.year
+    /** The [month] part as [Int] where [Month.January] is 1. */
+    val month1: Int get() = value.month1
+    /** The [month] part. */
+    val month: WMonth get() = value.month
+    /** The [day] part. */
+    val day: Int get() = value.day
+    /** The [year] part as [Year]. */
+    val yearYear: WYear get() = value.yearYear.wrapped
+
+    /** A [WDateTime] instance representing this date and time from the beginning of the [day]. */
+    val dateTimeDayStart get() = value.dateTimeDayStart.wrapped
+
+    /** The [dayOfYear] part. */
+    val dayOfYear get() = value.dayOfYear
+    /** The [dayOfWeek] part. */
+    val dayOfWeek get() = value.dayOfWeek
+    /** The [dayOfWeek] part as [Int]. */
+    val dayOfWeekInt get() = value.dayOfWeekInt
+
+    /** Converts this date to String using [format] for representing it. */
+    fun format(format: String) = value.format(format)
+    /** Converts this date to String using [format] for representing it. */
+    fun format(format: DateFormat) = value.format(format)
+
+    override fun compareTo(other: WDate): Int = this.value.compareTo(other.value)
+
+    operator fun plus(time: WTimeSpan) = (this.value + time.value).wrapped
+    operator fun plus(time: WMonthSpan) = (this.value + time.value).wrapped
+    operator fun plus(time: WDateTimeSpan) = (this.value + time.value).wrapped
+    operator fun plus(time: WTime) = (this.value + time.value).wrapped
+
+    override fun equals(other: Any?): Boolean = (other is WDate) && this.value == other.value
+    override fun hashCode(): Int = value.hashCode()
+    /** Converts this date to String formatting it like "2020-01-01", "2020-12-31" or "-2020-12-31" if the [year] is negative */
+    override fun toString(): String = value.toString()
+}

--- a/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WDateTime.kt
+++ b/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WDateTime.kt
@@ -1,0 +1,299 @@
+package com.soywiz.klock.wrapped
+
+import com.soywiz.klock.*
+import com.soywiz.klock.annotations.*
+import com.soywiz.klock.internal.*
+
+@KlockExperimental
+val DateTime.wrapped get() = WDateTime(this)
+
+/**
+ * Wrapped Version, that is not inline. You can use [value] to get the wrapped inline class.
+ *
+ * Represents a Date in UTC (GMT+00) with millisecond precision.
+ *
+ * It is internally represented as an inlined double, thus doesn't allocate in any target including JS.
+ * It can represent without loss dates between (-(2 ** 52) and (2 ** 52)):
+ * - Thu Aug 10 -140744 07:15:45 GMT-0014 (Central European Summer Time)
+ * - Wed May 23 144683 18:29:30 GMT+0200 (Central European Summer Time)
+ */
+@KlockExperimental
+class WDateTime(val value: DateTime) : Comparable<WDateTime> {
+    companion object {
+        /** It is a [WDateTime] instance representing 00:00:00 UTC, Thursday, 1 January 1970. */
+        val EPOCH get() = DateTime.EPOCH.wrapped
+
+        /**
+         * Constructs a new [WDateTime] from date and time information.
+         *
+         * This might throw a [DateException] on invalid dates.
+         */
+        operator fun invoke(
+            year: WYear,
+            month: Month,
+            day: Int,
+            hour: Int = 0,
+            minute: Int = 0,
+            second: Int = 0,
+            milliseconds: Int = 0
+        ) = DateTime(year.value, month, day, hour, minute, second, milliseconds).wrapped
+
+        /**
+         * Constructs a new [WDateTime] from date and time information.
+         *
+         * This might throw a [DateException] on invalid dates.
+         */
+        operator fun invoke(
+            date: WDate,
+            time: Time = Time(0.milliseconds)
+        ) = DateTime(date.value, time).wrapped
+
+        /**
+         * Constructs a new [WDateTime] from date and time information.
+         *
+         * This might throw a [DateException] on invalid dates.
+         */
+        operator fun invoke(
+            year: Int,
+            month: WMonth,
+            day: Int,
+            hour: Int = 0,
+            minute: Int = 0,
+            second: Int = 0,
+            milliseconds: Int = 0
+        ) = DateTime(year, month, day, hour, minute, second, milliseconds).wrapped
+
+        /**
+         * Constructs a new [WDateTime] from date and time information.
+         *
+         * This might throw a [DateException] on invalid dates.
+         */
+        operator fun invoke(
+            year: Int,
+            month: Int,
+            day: Int,
+            hour: Int = 0,
+            minute: Int = 0,
+            second: Int = 0,
+            milliseconds: Int = 0
+        ) = DateTime(year, month, day, hour, minute, second, milliseconds).wrapped
+
+        /**
+         * Constructs a new [WDateTime] from date and time information.
+         *
+         * On invalid dates, this function will try to adjust the specified invalid date to a valid one by clamping components.
+         */
+        fun createClamped(
+            year: Int,
+            month: Int,
+            day: Int,
+            hour: Int = 0,
+            minute: Int = 0,
+            second: Int = 0,
+            milliseconds: Int = 0
+        ) = DateTime.createClamped(year, month, day, hour, minute, second, milliseconds).wrapped
+
+        /**
+         * Constructs a new [WDateTime] from date and time information.
+         *
+         * On invalid dates, this function will try to adjust the specified invalid date to a valid one by adjusting other components.
+         */
+        fun createAdjusted(
+            year: Int,
+            month: Int,
+            day: Int,
+            hour: Int = 0,
+            minute: Int = 0,
+            second: Int = 0,
+            milliseconds: Int = 0
+        ) = DateTime.createAdjusted(year, month, day, hour, minute, second, milliseconds).wrapped
+
+        /**
+         * Constructs a new [WDateTime] from date and time information.
+         *
+         * On invalid dates, this function will have an undefined behaviour.
+         */
+        fun createUnchecked(
+            year: Int,
+            month: Int,
+            day: Int,
+            hour: Int = 0,
+            minute: Int = 0,
+            second: Int = 0,
+            milliseconds: Int = 0
+        ) = DateTime.createUnchecked(year, month, day, hour, minute, second, milliseconds).wrapped
+
+        /** Constructs a new [WDateTime] from a [unix] timestamp. */
+        operator fun invoke(unix: Long) = DateTime(unix).wrapped
+        /** Constructs a new [WDateTime] from a [unix] timestamp. */
+        operator fun invoke(unix: Double) = DateTime(unix).wrapped
+
+        /** Constructs a new [WDateTime] from a [unix] timestamp. */
+        fun fromUnix(unix: Double) = DateTime.fromUnix(unix).wrapped
+        /** Constructs a new [WDateTime] from a [unix] timestamp. */
+        fun fromUnix(unix: Long) = DateTime.fromUnix(unix).wrapped
+
+        /** Constructs a new [WDateTime] by parsing the [str] using standard date formats. */
+        fun fromString(str: String) = DateTime.fromString(str).wrapped
+        /** Constructs a new [WDateTime] by parsing the [str] using standard date formats. */
+        fun parse(str: String) = DateTime.parse(str).wrapped
+
+        /** Returns the current time as [WDateTime]. Note that since [WDateTime] is inline, this property doesn't allocate on JavaScript. */
+        fun now() = DateTime.now().wrapped
+        /** Returns the current local time as [WDateTimeTz]. */
+        fun nowLocal() = DateTime.nowLocal().wrapped
+
+        /** Returns the total milliseconds since unix epoch. The same as [nowUnixLong] but as double. To prevent allocation on targets without Long support. */
+        fun nowUnix(): Double = DateTime.nowUnix()
+        /** Returns the total milliseconds since unix epoch. */
+        fun nowUnixLong(): Long = DateTime.nowUnixLong()
+    }
+
+    /** Number of milliseconds since the 00:00:00 UTC, Monday, 1 January 1 */
+    val yearOneMillis: Double get() = value.yearOneMillis
+
+    /** The local offset for this date for the timezone of the device */
+    val localOffset: WTimezoneOffset get() = value.localOffset.wrapped
+
+    /** Number of milliseconds since UNIX [EPOCH] as [Double] */
+    val unixMillisDouble: Double get() = value.unixMillisDouble
+
+    /** Number of milliseconds since UNIX [EPOCH] as [Long] */
+    val unixMillisLong: Long get() = value.unixMillisLong
+
+    /** The [WYear] part */
+    val year: WYear get() = value.year.wrapped
+    /** The [WYear] part as [Int] */
+    val yearInt: Int get() = value.yearInt
+
+    /** The [WMonth] part */
+    val month: WMonth get() = value.month.wrapped
+    /** The [WMonth] part as [Int] where January is represented as 0 */
+    val month0: Int get() = value.month0
+    /** The [WMonth] part as [Int] where January is represented as 1 */
+    val month1: Int get() = value.month1
+
+    /** Represents a couple of [WYear] and [WMonth] that has leap information and thus allows to get the number of days of that month */
+    val yearMonth: WYearMonth get() = value.yearMonth.wrapped
+
+    /** The [dayOfMonth] part */
+    val dayOfMonth: Int get() = value.dayOfMonth
+
+    /** The [dayOfWeek] part */
+    val dayOfWeek: WDayOfWeek get() = value.dayOfWeek.wrapped
+    /** The [dayOfWeek] part as [Int] */
+    val dayOfWeekInt: Int get() = value.dayOfWeekInt
+
+    /** The [dayOfYear] part */
+    val dayOfYear: Int get() = value.dayOfYear
+
+    /** The [hours] part */
+    val hours: Int get() = value.hours
+    /** The [minutes] part */
+    val minutes: Int get() = value.minutes
+    /** The [seconds] part */
+    val seconds: Int get() = value.seconds
+    /** The [milliseconds] part */
+    val milliseconds: Int get() = value.milliseconds
+
+    /** Returns a new local date that will match these components. */
+    val localUnadjusted: WDateTimeTz get() = value.localUnadjusted.wrapped
+    /** Returns a new local date that will match these components but with a different [offset]. */
+    fun toOffsetUnadjusted(offset: WTimeSpan) = value.toOffsetUnadjusted(offset.value).wrapped
+    /** Returns a new local date that will match these components but with a different [offset]. */
+    fun toOffsetUnadjusted(offset: WTimezoneOffset) = value.toOffsetUnadjusted(offset.value).wrapped
+
+    /** Returns this date with the local offset of this device. Components might change because of the offset. */
+    val local: WDateTimeTz get() = value.local.wrapped
+    /** Returns this date with a local offset. Components might change because of the [offset]. */
+    fun toOffset(offset: WTimeSpan) = value.toOffset(offset.value).wrapped
+    /** Returns this date with a local offset. Components might change because of the [offset]. */
+    fun toOffset(offset: WTimezoneOffset) = value.toOffset(offset.value).wrapped
+    /** Returns this date with a 0 offset. Components are equal. */
+    val utc: WDateTimeTz get() = value.utc.wrapped
+
+    /** Returns a [WDateTime] of [this] day with the hour at 00:00:00 */
+    val dateDayStart get() = value.dateDayStart.wrapped
+    /** Returns a [WDateTime] of [this] day with the hour at 23:59:59.999 */
+    val dateDayEnd get() = value.dateDayEnd.wrapped
+
+    /** Returns the quarter 1, 2, 3 or 4 */
+    val quarter get() = value.quarter
+
+    // startOf
+
+    val startOfYear get() = value.startOfYear.wrapped
+    val startOfMonth get() = value.startOfMonth.wrapped
+    val startOfQuarter get() = value.startOfQuarter.wrapped
+    fun startOfDayOfWeek(day: WDayOfWeek) = value.startOfDayOfWeek(day).wrapped
+    val startOfWeek get() = value.startOfWeek.wrapped
+    val startOfIsoWeek get() = value.startOfIsoWeek.wrapped
+    val startOfDay get() = value.startOfDay.wrapped
+    val startOfHour get() = value.startOfHour.wrapped
+    val startOfMinute get() = value.startOfMinute.wrapped
+    val startOfSecond get() = value.startOfSecond.wrapped
+
+    // endOf
+
+    val endOfYear get() = value.endOfYear.wrapped
+    val endOfMonth get() = value.endOfMonth.wrapped
+    val endOfQuarter get() = value.endOfQuarter.wrapped
+    fun endOfDayOfWeek(day: WDayOfWeek) = value.endOfDayOfWeek(day).wrapped
+    val endOfWeek get() = value.endOfWeek.wrapped
+    val endOfIsoWeek get() = value.endOfIsoWeek.wrapped
+    val endOfDay get() = value.endOfDay.wrapped
+    val endOfHour get() = value.endOfHour.wrapped
+    val endOfMinute get() = value.endOfMinute.wrapped
+    val endOfSecond get() = value.endOfSecond.wrapped
+
+    val date get() = value.date.wrapped
+    val time get() = value.time.wrapped
+
+    operator fun plus(delta: WMonthSpan): WDateTime = (this.value + delta.value).wrapped
+    operator fun plus(delta: WDateTimeSpan): WDateTime = (this.value + delta.value).wrapped
+    operator fun plus(delta: WTimeSpan): WDateTime = (this.value + delta.value).wrapped
+
+    operator fun minus(delta: WMonthSpan): WDateTime = (this.value - delta.value).wrapped
+    operator fun minus(delta: WDateTimeSpan): WDateTime = (this.value - delta.value).wrapped
+    operator fun minus(delta: WTimeSpan): WDateTime = (this.value - delta.value).wrapped
+
+    operator fun minus(other: WDateTime): WTimeSpan = (this.value - other.value).wrapped
+
+    override fun compareTo(other: WDateTime): Int = this.value.compareTo(other.value)
+
+    /** Constructs a new [WDateTime] after adding [deltaMonths] and [deltaMilliseconds] */
+    fun add(deltaMonths: Int, deltaMilliseconds: Double): WDateTime = value.add(deltaMonths, deltaMilliseconds).wrapped
+
+    /** Constructs a new [WDateTime] after adding [dateSpan] and [timeSpan] */
+    fun add(dateSpan: WMonthSpan, timeSpan: WTimeSpan): WDateTime = value.add(dateSpan.value, timeSpan.value).wrapped
+
+    fun copyDayOfMonth(
+        year: WYear = this.year,
+        month: WMonth = this.month,
+        dayOfMonth: Int = this.dayOfMonth,
+        hours: Int = this.hours,
+        minutes: Int = this.minutes,
+        seconds: Int = this.seconds,
+        milliseconds: Int = this.milliseconds
+    ) = DateTime(year.value, month, dayOfMonth, hours, minutes, seconds, milliseconds).wrapped
+
+    /** Converts this date to String using [format] for representing it */
+    fun format(format: DateFormat): String = value.format(format)
+    /** Converts this date to String using [format] for representing it */
+    fun format(format: String): String = value.format(format)
+
+    /** Converts this date to String using [format] for representing it */
+    fun toString(format: String): String = value.format(format)
+    /** Converts this date to String using [format] for representing it */
+    fun toString(format: DateFormat): String = value.format(format)
+
+    /** Converts this date to String using the [DateFormat.DEFAULT_FORMAT] for representing it */
+    override fun toString(): String = value.toString()
+}
+
+@KlockExperimental
+fun max(a: WDateTime, b: WDateTime): WDateTime = max(a.value, b.value).wrapped
+@KlockExperimental
+fun min(a: WDateTime, b: WDateTime): WDateTime = min(a.value, b.value).wrapped
+@KlockExperimental
+fun WDateTime.clamp(min: WDateTime, max: WDateTime): WDateTime = this.value.clamp(min.value, max.value).wrapped

--- a/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WDateTimeSpan.kt
+++ b/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WDateTimeSpan.kt
@@ -1,0 +1,15 @@
+package com.soywiz.klock.wrapped
+
+import com.soywiz.klock.*
+import com.soywiz.klock.annotations.*
+
+@KlockExperimental
+val DateTimeSpan.wrapped get() = WDateTimeSpan(this)
+@KlockExperimental
+val WDateTimeSpan.value get() = this
+@KlockExperimental
+fun WDateTimeSpan(value: DateTimeSpan) = value
+
+// It is not inline
+//@KlockExperimental
+typealias WDateTimeSpan = DateTimeSpan

--- a/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WDateTimeTz.kt
+++ b/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WDateTimeTz.kt
@@ -1,0 +1,14 @@
+package com.soywiz.klock.wrapped
+
+import com.soywiz.klock.*
+import com.soywiz.klock.annotations.*
+
+@KlockExperimental
+val DateTimeTz.wrapped get() = this
+@KlockExperimental
+val WDateTimeTz.value get() = this
+@KlockExperimental
+fun WDateTimeTz(value: DateTimeTz) = value
+
+// Not inline
+typealias WDateTimeTz = DateTimeTz

--- a/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WDayOfWeek.kt
+++ b/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WDayOfWeek.kt
@@ -1,0 +1,14 @@
+package com.soywiz.klock.wrapped
+
+import com.soywiz.klock.*
+import com.soywiz.klock.annotations.*
+
+@KlockExperimental
+val DayOfWeek.wrapped get() = this
+@KlockExperimental
+val WDayOfWeek.value get() = this
+@KlockExperimental
+fun WDayOfWeek(value: DayOfWeek) = value
+
+// Enum, not inline
+typealias WDayOfWeek = DayOfWeek

--- a/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WMonth.kt
+++ b/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WMonth.kt
@@ -1,0 +1,14 @@
+package com.soywiz.klock.wrapped
+
+import com.soywiz.klock.*
+import com.soywiz.klock.annotations.*
+
+@KlockExperimental
+val Month.wrapped get() = this
+@KlockExperimental
+val WMonth.value get() = this
+@KlockExperimental
+fun WMonth(value: Month) = value
+
+// An enum, thus not inline
+typealias WMonth = Month

--- a/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WMonthSpan.kt
+++ b/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WMonthSpan.kt
@@ -1,0 +1,42 @@
+package com.soywiz.klock.wrapped
+
+import com.soywiz.klock.*
+import com.soywiz.klock.annotations.*
+
+@KlockExperimental
+val MonthSpan.wrapped get() = WMonthSpan(this)
+
+/**
+ * Wrapped Version, that is not inline. You can use [value] to get the wrapped inline class.
+ *
+ * Represents a number of years and months temporal distance.
+ */
+@KlockExperimental
+class WMonthSpan(val value: MonthSpan) : Comparable<WMonthSpan> {
+    val totalMonths: Int get() = value.totalMonths
+    /** Total years of this [WMonthSpan] as double (might contain decimals) */
+    val totalYears: Double get() = value.totalYears
+    /** Years part of this [WMonthSpan] as integer */
+    val years: Int get() = value.years
+    /** Months part of this [WMonthSpan] as integer */
+    val months: Int get() = value.months
+
+    operator fun unaryMinus() = (-value).wrapped
+    operator fun unaryPlus() = (+value).wrapped
+
+    operator fun plus(other: WTimeSpan) = (this.value + other.value).wrapped
+    operator fun plus(other: WMonthSpan) = (this.value + other.value).wrapped
+    operator fun plus(other: WDateTimeSpan) = (this.value + other.value).wrapped
+
+    operator fun minus(other: WTimeSpan) = (this.value - other.value).wrapped
+    operator fun minus(other: WMonthSpan) = (this.value - other.value).wrapped
+    operator fun minus(other: WDateTimeSpan) = (this.value - other.value).wrapped
+
+    inline operator fun times(times: Number) = (value * times).wrapped
+    inline operator fun div(times: Number) = (value / times).wrapped
+
+    override fun compareTo(other: WMonthSpan): Int = this.value.compareTo(other.value)
+
+    /** Converts this time to String formatting it like "20Y", "20Y 1M", "1M" or "0M". */
+    override fun toString(): String = value.toString()
+}

--- a/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WTime.kt
+++ b/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WTime.kt
@@ -1,0 +1,47 @@
+package com.soywiz.klock.wrapped
+
+import com.soywiz.klock.*
+import com.soywiz.klock.annotations.*
+
+@KlockExperimental
+val Time.wrapped get() = WTime(this)
+
+/**
+ * Wrapped Version, that is not inline. You can use [value] to get the wrapped inline class.
+ *
+ * Represents a union of [millisecond], [second], [minute] and [hour].
+ */
+@KlockExperimental
+class WTime(val value: Time) : Comparable<WTime> {
+    companion object {
+        /** Constructs a new [WTime] from the [hour], [minute], [second] and [millisecond] components. */
+        operator fun invoke(hour: Int, minute: Int = 0, second: Int = 0, millisecond: Int = 0): WTime =
+            Time(hour, minute, second, millisecond).wrapped
+    }
+    /** The [millisecond] part. */
+    val millisecond: Int get() = value.millisecond
+    /** The [second] part. */
+    val second: Int get() = value.second
+    /** The [minute] part. */
+    val minute: Int get() = value.minute
+    /** The [hour] part. */
+    val hour: Int get() = value.hour
+    /** The [hour] part adjusted to 24-hour format. */
+    val hourAdjusted: Int get() = value.hourAdjusted
+
+    /** Returns new [WTime] instance adjusted to 24-hour format. */
+    fun adjust(): WTime = value.adjust().wrapped
+
+    /** Converts this date to String using [format] for representing it. */
+    fun format(format: String) = value.format(format)
+    /** Converts this date to String using [format] for representing it. */
+    fun format(format: TimeFormat) = value.format(format)
+
+    /** Converts this time to String formatting it like "00:00:00.000", "23:59:59.999" or "-23:59:59.999" if the [hour] is negative */
+    override fun toString(): String = value.toString()
+
+    override fun compareTo(other: WTime): Int = this.value.compareTo(other.value)
+}
+
+@KlockExperimental
+operator fun WTime.plus(span: WTimeSpan) = (this.value + span.value).wrapped

--- a/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WTimeSpan.kt
+++ b/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WTimeSpan.kt
@@ -1,0 +1,98 @@
+package com.soywiz.klock.wrapped
+
+import com.soywiz.klock.*
+import com.soywiz.klock.annotations.*
+import com.soywiz.klock.internal.*
+
+@KlockExperimental
+val TimeSpan.wrapped get() = WTimeSpan(this)
+
+/**
+ * Wrapped Version, that is not inline. You can use [value] to get the wrapped inline class.
+ *
+ * Represents a span of time, with [milliseconds] precision.
+ *
+ * It is an inline class wrapping [Double] instead of [Long] to work on JavaScript without allocations.
+ */
+@KlockExperimental
+class WTimeSpan(val value: TimeSpan) : Comparable<WTimeSpan> {
+    val milliseconds: Double get() = value.milliseconds
+    /** Returns the total number of [nanoseconds] for this [WTimeSpan] (1 / 1_000_000_000 [seconds]) */
+    val nanoseconds: Double get() = value.nanoseconds
+    /** Returns the total number of [microseconds] for this [WTimeSpan] (1 / 1_000_000 [seconds]) */
+    val microseconds: Double get() = value.microseconds
+    /** Returns the total number of [seconds] for this [WTimeSpan] */
+    val seconds: Double get() = value.seconds
+    /** Returns the total number of [minutes] for this [WTimeSpan] (60 [seconds]) */
+    val minutes: Double get() = value.minutes
+    /** Returns the total number of [hours] for this [WTimeSpan] (3_600 [seconds]) */
+    val hours: Double get() = value.hours
+    /** Returns the total number of [days] for this [WTimeSpan] (86_400 [seconds]) */
+    val days: Double get() = value.days
+    /** Returns the total number of [weeks] for this [WTimeSpan] (604_800 [seconds]) */
+    val weeks: Double get() = value.weeks
+
+    /** Returns the total number of [milliseconds] as a [Long] */
+    val millisecondsLong: Long get() = value.millisecondsLong
+    /** Returns the total number of [milliseconds] as an [Int] */
+    val millisecondsInt: Int get() = value.millisecondsInt
+
+    override fun compareTo(other: WTimeSpan): Int = value.compareTo(other.value)
+
+    operator fun unaryMinus() = (-value).wrapped
+    operator fun unaryPlus() = (+value).wrapped
+
+    operator fun plus(other: WTimeSpan): WTimeSpan = (value + other.value).wrapped
+    operator fun plus(other: WMonthSpan): WDateTimeSpan = (value + other.value).wrapped
+    operator fun plus(other: WDateTimeSpan): WDateTimeSpan = (value + other).wrapped
+
+    operator fun minus(other: WTimeSpan): WTimeSpan = (this.value - other.value).wrapped
+    operator fun minus(other: WMonthSpan): WDateTimeSpan = (this.value - other.value).wrapped
+    operator fun minus(other: WDateTimeSpan): WDateTimeSpan = (this.value - other.value).wrapped
+
+    operator fun times(scale: Int): WTimeSpan = (value * scale).wrapped
+    operator fun times(scale: Double): WTimeSpan = (value * scale).wrapped
+
+    operator fun div(scale: Int): WTimeSpan = (value / scale).wrapped
+    operator fun div(scale: Double): WTimeSpan = (value / scale).wrapped
+
+    operator fun div(other: WTimeSpan): Double = this.value / other.value
+    operator fun rem(other: WTimeSpan): WTimeSpan = (this.value % other.value).wrapped
+
+    companion object {
+        /**
+         * Zero time.
+         */
+        val ZERO get() = TimeSpan.ZERO.wrapped
+
+        /**
+         * Represents an invalid TimeSpan.
+         * Useful to represent an alternative "null" time lapse
+         * avoiding the boxing of a nullable type.
+         */
+        val NULL get() = TimeSpan.NULL.wrapped
+    }
+
+    /**
+     * Formats this [WTimeSpan] into something like `12:30:40.100`.
+     *
+     * For 3 hour, 20 minutes and 15 seconds
+     *
+     * 1 [components] (seconds): 12015
+     * 2 [components] (minutes): 200:15
+     * 3 [components] (hours)  : 03:20:15
+     * 4 [components] (days)   : 00:03:20:15
+     *
+     * With milliseconds would add decimals to the seconds part.
+     */
+    fun toTimeString(components: Int = 3, addMilliseconds: Boolean = false): String = value.toTimeString(components, addMilliseconds)
+
+    override fun toString(): String = value.toString()
+}
+
+@KlockExperimental
+fun max(a: WTimeSpan, b: WTimeSpan): WTimeSpan = max(a.value, b.value).wrapped
+@KlockExperimental
+fun min(a: WTimeSpan, b: WTimeSpan): WTimeSpan = min(a.value, b.value).wrapped
+@KlockExperimental
+fun WTimeSpan.clamp(min: WTimeSpan, max: WTimeSpan) = value.clamp(min.value, max.value).wrapped

--- a/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WTimezoneOffset.kt
+++ b/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WTimezoneOffset.kt
@@ -1,0 +1,51 @@
+package com.soywiz.klock.wrapped
+
+import com.soywiz.klock.*
+import com.soywiz.klock.annotations.*
+
+@KlockExperimental
+val TimezoneOffset.wrapped get() = WTimezoneOffset(this)
+
+/**
+ * Wrapped Version, that is not inline. You can use [value] to get the wrapped inline class.
+ *
+ * Represents a time zone offset with millisecond precision. Usually minute is enough.
+ * Can be used along [WDateTimeTz] to construct non universal, local times.
+ *
+ * This class is inlined so no boxing should be required.
+ */
+@KlockExperimental
+class WTimezoneOffset(val value: TimezoneOffset) {
+    /** Returns whether this [WTimezoneOffset] has a positive component */
+    val positive: Boolean get() = value.positive
+
+    /** [WTimeSpan] time for this [WTimezoneOffset] */
+    val time get() = value.time.wrapped
+
+    /** [WTimezoneOffset] in [totalMinutes] */
+    val totalMinutes: Double get() = value.totalMinutes
+
+    /** [WTimezoneOffset] in [totalMinutes] as integer */
+    val totalMinutesInt get() = value.totalMinutesInt
+
+    /** Returns a string representation of this [WTimezoneOffset] */
+    val timeZone: String get() = value.timeZone
+
+    override fun toString(): String = value.toString()
+
+    companion object {
+        /** Constructs a new [WTimezoneOffset] from a [WTimeSpan]. */
+        operator fun invoke(time: WTimeSpan) = TimezoneOffset(time.value).wrapped
+
+        /**
+         * Returns timezone offset as a [WTimeSpan], for a specified [time].
+         * For example, GMT+01 would return 60.minutes.
+         * This uses the Operating System to compute daylight offsets when required.
+         */
+        fun local(time: WDateTime) = TimezoneOffset.local(time.value).wrapped
+    }
+}
+
+/** A [WTimeSpan] as a [WTimezoneOffset]. */
+@KlockExperimental
+val WTimeSpan.offset get() = this.value.offset.wrapped

--- a/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WYear.kt
+++ b/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WYear.kt
@@ -1,0 +1,104 @@
+package com.soywiz.klock.wrapped
+
+import com.soywiz.klock.*
+import com.soywiz.klock.annotations.*
+
+@KlockExperimental
+val Year.wrapped get() = WYear(this)
+
+/**
+ * Wrapped Version, that is not inline. You can use [value] to get the wrapped inline class.
+ *
+ * Represents a Year in a typed way.
+ *
+ * A year is a set of 365 days or 366 for leap years.
+ * It is the time it takes the earth to fully orbit the sun.
+ *
+ * The integrated model is capable of determine if a year is leap for years 1 until 9999 inclusive.
+ */
+@KlockExperimental
+class WYear(val value: Year) : Comparable<WYear> {
+    companion object {
+        /**
+         * Creates a Year instance checking that the year is between 1 and 9999 inclusive.
+         *
+         * It throws a [DateException] if the year is not in the 1..9999 range.
+         */
+        fun checked(year: Int) = Year(year).wrapped
+
+        /**
+         * Determines if a year is leap checking that the year is between 1..9999 or throwing a [DateException] when outside that range.
+         */
+        fun isLeapChecked(year: Int): Boolean = Year.isLeapChecked(year)
+
+        /**
+         * Determines if a year is leap. The model works for years between 1..9999. Outside this range, the result might be invalid.
+         */
+        fun isLeap(year: Int): Boolean = Year.isLeap(year)
+
+        /**
+         * Computes the year from the number of days since 0001-01-01.
+         */
+        fun fromDays(days: Int): WYear = Year.fromDays(days).wrapped
+
+        /**
+         * Get the number of days of a year depending on being leap or not.
+         * Normal, non leap years contain 365 days, while leap ones 366.
+         */
+        fun days(isLeap: Boolean) = Year.days(isLeap)
+
+        /**
+         * Return the number of leap years that happened between 1 and the specified [year].
+         */
+        fun leapCountSinceOne(year: Int): Int = Year.leapCountSinceOne(year)
+
+        /**
+         * Number of days since 1 and the beginning of the specified [year].
+         */
+        fun daysSinceOne(year: Int): Int = Year.daysSinceOne(year)
+
+        /**
+         * Number of days in a normal year.
+         */
+        const val DAYS_COMMON = Year.DAYS_COMMON
+
+        /**
+         * Number of days in a leap year.
+         */
+        const val DAYS_LEAP = Year.DAYS_LEAP
+    }
+
+    /**
+     * Determines if this year is leap checking that the year is between 1..9999 or throwing a [DateException] when outside that range.
+     */
+    val isLeapChecked get() = value.isLeapChecked
+
+    /**
+     * Determines if this year is leap. The model works for years between 1..9999. Outside this range, the result might be invalid.
+     */
+    val isLeap get() = value.isLeap
+
+    /**
+     * Total days of this year, 365 (non leap) [DAYS_COMMON] or 366 (leap) [DAYS_LEAP].
+     */
+    val days: Int get() = value.days
+
+    /**
+     * Number of leap years since the year 1 (without including this one)
+     */
+    val leapCountSinceOne: Int get() = value.leapCountSinceOne
+
+    /**
+     * Number of days since year 1 to reach this year
+     */
+    val daysSinceOne: Int get() = value.daysSinceOne
+
+    /**
+     * Compares two years.
+     */
+    override fun compareTo(other: WYear): Int = this.value.compareTo(other.value)
+
+    operator fun plus(delta: Int): WYear = (value + delta).wrapped
+    operator fun minus(delta: Int): WYear = (value - delta).wrapped
+    operator fun minus(other: WYear): Int = value - other.value
+}

--- a/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WYearMonth.kt
+++ b/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WYearMonth.kt
@@ -1,0 +1,58 @@
+package com.soywiz.klock.wrapped
+
+import com.soywiz.klock.*
+import com.soywiz.klock.annotations.*
+
+@KlockExperimental
+val YearMonth.wrapped get() = WYearMonth(this)
+
+/**
+ * Wrapped Version, that is not inline. You can use [value] to get the wrapped inline class.
+ *
+ * Represents a couple of [year] and [month].
+ */
+@KlockExperimental
+class WYearMonth(val value: YearMonth) {
+    companion object {
+        /** Constructs a new [WYearMonth] from the [year] and [month] components. */
+        operator fun invoke(year: WYear, month: WMonth) = YearMonth(year.value, month).wrapped
+        /** Constructs a new [WYearMonth] from the [year] and [month] components. */
+        operator fun invoke(year: Int, month: WMonth) = YearMonth(year, month).wrapped
+        /** Constructs a new [WYearMonth] from the [year] and [month] components. */
+        operator fun invoke(year: Int, month1: Int) = YearMonth(year, month1).wrapped
+    }
+
+    /** The [year] part. */
+    val year: Year get() = value.year
+    /** The [year] part as [Int]. */
+    val yearInt: Int get() = value.yearInt
+
+    /** The [month] part. */
+    val month: WMonth get() = value.month
+    /** The [month] part as [Int] where [Month.January] is 1. */
+    val month1: Int get() = value.month1
+
+    /** Days in this [month] of this [year]. */
+    val days: Int get() = value.days
+    /** Number of days since the start of the [year] to reach this [month]. */
+    val daysToStart: Int get() = value.daysToStart
+    /** Number of days since the start of the [year] to reach next [month]. */
+    val daysToEnd: Int get() = value.daysToEnd
+
+    operator fun plus(span: WMonthSpan): WYearMonth  = (this.value + span.value).wrapped
+    operator fun minus(span: WMonthSpan): WYearMonth = (this.value - span.value).wrapped
+
+    override fun toString(): String = "$month $yearInt"
+}
+
+/**
+ * Creates a [WYearMonth] representing [this] year and this [month].
+ */
+@KlockExperimental
+fun WYear.withMonth(month: WMonth) = this.value.withMonth(month).wrapped
+
+/**
+ * Creates a [WYearMonth] representing this [year] and [this] month.
+ */
+@KlockExperimental
+fun WMonth.withYear(year: WYear) = this.withYear(year.value).wrapped


### PR DESCRIPTION
It should play nice with reflection and interoperability without a separate artifact.

* To wrap: `.wrapped`
* To unwrap: `.value`