### PR TITLE
Added Github Actions Task to DEPLOY.yml

### DIFF
--- a/.github/workflows/DEPLOY.yml
+++ b/.github/workflows/DEPLOY.yml
@@ -42,3 +42,28 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: ./gradlew actuallyPublishBintray
+
+  publishVersionNumbers:
+    needs: [publish-finalize]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get repository name
+        run:  echo "::set-env name=REPOSITORY_NAME::$(echo "$GITHUB_REPOSITORY" | awk -F / '{print $2}')"
+
+      - name: Get version
+        run:  echo "::set-env name=VERSION::${GITHUB_REF/refs\/tags\/v/}"
+
+      - name: Checkout korlibs-versions repo
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.KORGEBOT_TOKEN }}
+          repository: korlibs/korlibs-versions
+
+      - name: Bump version numbers
+        run: |
+          sed -i 's/'$REPOSITORY_NAME'Version=.*/'$REPOSITORY_NAME'Version='$VERSION'/g' versions.ver
+          git config --global user.email "githubactionsbot@korge.org"
+          git config --global user.name "korgebot"
+          git add versions.ver
+          git commit -m "${{ env.REPOSITORY_NAME }} bump to ${{ env.VERSION }}" -m "Bumped ${{ env.REPOSITORY_NAME }} version number to ${{ env.VERSION }}"
+          git push


### PR DESCRIPTION
which pushed the version number of the current repo to korlibs-versions.

It gets the version from the release tag starting with `v` and the repository name to concatenate it to: `${REPOSITORY_NAME}Version=${TAG_WITHOUT_LEADING_v}` and updates this matching String on `versions.ver` in the korlibs-versions repository