### PR TITLE
#127 Wrapped classes to be data classes, to ensure value equality

### DIFF
--- a/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WDate.kt
+++ b/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WDate.kt
@@ -15,7 +15,7 @@ val Date.wrapped get() = WDate(this)
  * It is packed in an inline class wrapping an Int to prevent allocations.
  */
 @KlockExperimental
-class WDate(val value: Date) : Comparable<WDate>, Serializable {
+data class WDate(val value: Date) : Comparable<WDate>, Serializable {
     companion object {
         @Suppress("MayBeConstant", "unused")
         private const val serialVersionUID = 1L
@@ -63,8 +63,6 @@ class WDate(val value: Date) : Comparable<WDate>, Serializable {
     operator fun plus(time: WDateTimeSpan) = (this.value + time.value).wrapped
     operator fun plus(time: WTime) = (this.value + time.value).wrapped
 
-    override fun equals(other: Any?): Boolean = (other is WDate) && this.value == other.value
-    override fun hashCode(): Int = value.hashCode()
     /** Converts this date to String formatting it like "2020-01-01", "2020-12-31" or "-2020-12-31" if the [year] is negative */
     override fun toString(): String = value.toString()
 }

--- a/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WDateTime.kt
+++ b/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WDateTime.kt
@@ -18,7 +18,7 @@ val DateTime.wrapped get() = WDateTime(this)
  * - Wed May 23 144683 18:29:30 GMT+0200 (Central European Summer Time)
  */
 @KlockExperimental
-class WDateTime(val value: DateTime) : Comparable<WDateTime>, Serializable {
+data class WDateTime(val value: DateTime) : Comparable<WDateTime>, Serializable {
     companion object {
         @Suppress("MayBeConstant", "unused")
         private const val serialVersionUID = 1L

--- a/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WMonthSpan.kt
+++ b/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WMonthSpan.kt
@@ -13,7 +13,7 @@ val MonthSpan.wrapped get() = WMonthSpan(this)
  * Represents a number of years and months temporal distance.
  */
 @KlockExperimental
-class WMonthSpan(val value: MonthSpan) : Comparable<WMonthSpan>, Serializable {
+data class WMonthSpan(val value: MonthSpan) : Comparable<WMonthSpan>, Serializable {
     companion object {
         @Suppress("MayBeConstant", "unused")
         private const val serialVersionUID = 1L

--- a/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WTime.kt
+++ b/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WTime.kt
@@ -13,7 +13,7 @@ val Time.wrapped get() = WTime(this)
  * Represents a union of [millisecond], [second], [minute] and [hour].
  */
 @KlockExperimental
-class WTime(val value: Time) : Comparable<WTime>, Serializable {
+data class WTime(val value: Time) : Comparable<WTime>, Serializable {
     companion object {
         @Suppress("MayBeConstant", "unused")
         private const val serialVersionUID = 1L

--- a/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WTimeSpan.kt
+++ b/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WTimeSpan.kt
@@ -15,7 +15,7 @@ val TimeSpan.wrapped get() = WTimeSpan(this)
  * It is an inline class wrapping [Double] instead of [Long] to work on JavaScript without allocations.
  */
 @KlockExperimental
-class WTimeSpan(val value: TimeSpan) : Comparable<WTimeSpan>, Serializable {
+data class WTimeSpan(val value: TimeSpan) : Comparable<WTimeSpan>, Serializable {
     val milliseconds: Double get() = value.milliseconds
     /** Returns the total number of [nanoseconds] for this [WTimeSpan] (1 / 1_000_000_000 [seconds]) */
     val nanoseconds: Double get() = value.nanoseconds

--- a/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WTimezoneOffset.kt
+++ b/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WTimezoneOffset.kt
@@ -16,7 +16,7 @@ val TimezoneOffset.wrapped get() = WTimezoneOffset(this)
  * This class is inlined so no boxing should be required.
  */
 @KlockExperimental
-class WTimezoneOffset(val value: TimezoneOffset) : Serializable {
+data class WTimezoneOffset(val value: TimezoneOffset) : Serializable {
     /** Returns whether this [WTimezoneOffset] has a positive component */
     val positive: Boolean get() = value.positive
 

--- a/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WYear.kt
+++ b/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WYear.kt
@@ -18,7 +18,7 @@ val Year.wrapped get() = WYear(this)
  * The integrated model is capable of determine if a year is leap for years 1 until 9999 inclusive.
  */
 @KlockExperimental
-class WYear(val value: Year) : Comparable<WYear>, Serializable {
+data class WYear(val value: Year) : Comparable<WYear>, Serializable {
     companion object {
         @Suppress("MayBeConstant", "unused")
         private const val serialVersionUID = 1L

--- a/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WYearMonth.kt
+++ b/klock/src/commonMain/kotlin/com/soywiz/klock/wrapped/WYearMonth.kt
@@ -13,7 +13,7 @@ val YearMonth.wrapped get() = WYearMonth(this)
  * Represents a couple of [year] and [month].
  */
 @KlockExperimental
-class WYearMonth(val value: YearMonth) : Serializable {
+data class WYearMonth(val value: YearMonth) : Serializable {
     companion object {
         @Suppress("MayBeConstant", "unused")
         private const val serialVersionUID = 1L

--- a/klock/src/commonTest/kotlin/com/soywiz/klock/wrapped/WDateTest.kt
+++ b/klock/src/commonTest/kotlin/com/soywiz/klock/wrapped/WDateTest.kt
@@ -1,0 +1,11 @@
+package com.soywiz.klock.wrapped
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class WDateTest {
+    @Test
+    fun `ensureEqualityComparisonIsByValue`() {
+        assertEquals(WDate(2010, 1, 1), WDate(2010, 1, 1))
+    }
+}

--- a/klock/src/commonTest/kotlin/com/soywiz/klock/wrapped/WDateTimeTest.kt
+++ b/klock/src/commonTest/kotlin/com/soywiz/klock/wrapped/WDateTimeTest.kt
@@ -1,0 +1,11 @@
+package com.soywiz.klock.wrapped
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class WDateTimeTest {
+    @Test
+    fun `ensureEqualityComparisonIsByValue`() {
+        assertEquals(WDateTime(2010, 1, 1), WDateTime(2010, 1, 1))
+    }
+}

--- a/klock/src/commonTest/kotlin/com/soywiz/klock/wrapped/WMonthSpanTest.kt
+++ b/klock/src/commonTest/kotlin/com/soywiz/klock/wrapped/WMonthSpanTest.kt
@@ -1,0 +1,12 @@
+package com.soywiz.klock.wrapped
+
+import com.soywiz.klock.MonthSpan
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class WMonthSpanTest {
+    @Test
+    fun `ensureEqualityComparisonIsByValue`() {
+        assertEquals(WMonthSpan(MonthSpan(1)), WMonthSpan((MonthSpan(1))))
+    }
+}

--- a/klock/src/commonTest/kotlin/com/soywiz/klock/wrapped/WTimeSpanTest.kt
+++ b/klock/src/commonTest/kotlin/com/soywiz/klock/wrapped/WTimeSpanTest.kt
@@ -1,0 +1,12 @@
+package com.soywiz.klock.wrapped
+
+import com.soywiz.klock.TimeSpan
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class WTimeSpanTest {
+    @Test
+    fun `ensureEqualityComparisonIsByValue`() {
+        assertEquals(WTimeSpan(TimeSpan(10.0)), WTimeSpan(TimeSpan(10.0)))
+    }
+}

--- a/klock/src/commonTest/kotlin/com/soywiz/klock/wrapped/WTimeTest.kt
+++ b/klock/src/commonTest/kotlin/com/soywiz/klock/wrapped/WTimeTest.kt
@@ -1,0 +1,11 @@
+package com.soywiz.klock.wrapped
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class WTimeTest {
+    @Test
+    fun `ensureEqualityComparisonIsByValue`() {
+        assertEquals(WTime(10), WTime(10))
+    }
+}

--- a/klock/src/commonTest/kotlin/com/soywiz/klock/wrapped/WTimezoneOffsetTest.kt
+++ b/klock/src/commonTest/kotlin/com/soywiz/klock/wrapped/WTimezoneOffsetTest.kt
@@ -1,0 +1,12 @@
+package com.soywiz.klock.wrapped
+
+import com.soywiz.klock.TimezoneOffset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class WTimezoneOffsetTest {
+    @Test
+    fun `ensureEqualityComparisonIsByValue`() {
+        assertEquals(WTimezoneOffset(TimezoneOffset(10.0)), WTimezoneOffset(TimezoneOffset(10.0)))
+    }
+}

--- a/klock/src/commonTest/kotlin/com/soywiz/klock/wrapped/WYearMonthTest.kt
+++ b/klock/src/commonTest/kotlin/com/soywiz/klock/wrapped/WYearMonthTest.kt
@@ -1,0 +1,12 @@
+package com.soywiz.klock.wrapped
+
+import com.soywiz.klock.Year
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class WYearMonthTest {
+    @Test
+    fun `ensureEqualityComparisonIsByValue`() {
+        assertEquals(WYearMonth(10, 1), WYearMonth(10, 1))
+    }
+}

--- a/klock/src/commonTest/kotlin/com/soywiz/klock/wrapped/WYearTest.kt
+++ b/klock/src/commonTest/kotlin/com/soywiz/klock/wrapped/WYearTest.kt
@@ -1,0 +1,13 @@
+package com.soywiz.klock.wrapped
+
+import com.soywiz.klock.TimezoneOffset
+import com.soywiz.klock.Year
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class WYearTest {
+    @Test
+    fun `ensureEqualityComparisonIsByValue`() {
+        assertEquals(WYear(Year(10)), WYear(Year(10)))
+    }
+}


### PR DESCRIPTION
This fixes #127 , ensuring all the wrapped classes behave as expected when performing equality comparison.