### PR TITLE
add DATETIME_UTC_COMPLETE and DATETIME_UTC_COMPLETE_FRACTION

### DIFF
--- a/klock/src/commonMain/kotlin/com/soywiz/klock/PatternDateFormat.kt
+++ b/klock/src/commonMain/kotlin/com/soywiz/klock/PatternDateFormat.kt
@@ -208,22 +208,7 @@ data class PatternDateFormat @JvmOverloads constructor(
             when (name) {
                 "E", "EE", "EEE", "EEEE", "EEEEE", "EEEEEE" -> Unit // day of week (Sun | Sunday)
                 "z", "zzz" -> { // timezone (GMT)
-                    val tzOffset = tzNames.namesToOffsets[value.toUpperCase()]
-                    if (tzOffset != null) {
-                        offset = tzOffset
-                    } else {
-                        var sign = +1
-                        val reader = MicroStrReader(value)
-                        reader.tryRead("GMT")
-                        reader.tryRead("UTC")
-                        if (reader.tryRead("+")) sign = +1
-                        if (reader.tryRead("-")) sign = -1
-                        val part = reader.readRemaining().replace(":", "")
-                        val hours = part.substr(0, 2).padStart(2, '0').toIntOrNull() ?: 0
-                        val minutes = part.substr(2, 2).padStart(2, '0').toIntOrNull() ?: 0
-                        val roffset = hours.hours + minutes.minutes
-                        offset = if (sign > 0) +roffset else -roffset
-                    }
+                    offset = MicroStrReader(value).readTimeZoneOffset(tzNames)
                 }
                 "d", "dd" -> day = value.toInt()
                 "M", "MM" -> month = value.toInt()

--- a/klock/src/commonMain/kotlin/com/soywiz/klock/internal/TimeZoneParser.kt
+++ b/klock/src/commonMain/kotlin/com/soywiz/klock/internal/TimeZoneParser.kt
@@ -1,0 +1,24 @@
+package com.soywiz.klock.internal
+
+import com.soywiz.klock.TimeSpan
+import com.soywiz.klock.TimezoneNames
+import com.soywiz.klock.hours
+import com.soywiz.klock.minutes
+
+internal fun MicroStrReader.readTimeZoneOffset(tzNames: TimezoneNames = TimezoneNames.DEFAULT): TimeSpan? {
+    val reader = this
+    for ((name, offset) in tzNames.namesToOffsets) {
+        if (name == "GMT" || name == "UTC") continue
+        if (reader.tryRead(name)) return offset
+    }
+    if (reader.tryRead('Z')) return 0.minutes
+    var sign = +1
+    if (!reader.tryRead("GMT") && !reader.tryRead("UTC")) return null
+    if (reader.tryRead("+")) sign = +1
+    if (reader.tryRead("-")) sign = -1
+    val part = reader.readRemaining().replace(":", "")
+    val hours = part.substr(0, 2).padStart(2, '0').toIntOrNull() ?: 0
+    val minutes = part.substr(2, 2).padStart(2, '0').toIntOrNull() ?: 0
+    val roffset = hours.hours + minutes.minutes
+    return if (sign > 0) +roffset else -roffset
+}

--- a/klock/src/commonTest/kotlin/com/soywiz/klock/ISO8601Test.kt
+++ b/klock/src/commonTest/kotlin/com/soywiz/klock/ISO8601Test.kt
@@ -97,6 +97,24 @@ class ISO8601Test {
     }
 
     @Test
+    fun testDateTimeUtcComplete() {
+        assertEquals("20190917T114805Z", ISO8601.DATETIME_UTC_COMPLETE.basic.format(1568720885000))
+        assertEquals("2019-09-17T11:48:05Z", ISO8601.DATETIME_UTC_COMPLETE.extended.format(1568720885000))
+
+        assertEquals("Tue, 17 Sep 2019 11:48:05 UTC", ISO8601.DATETIME_UTC_COMPLETE.parse("20190917T114805Z").utc.toString())
+        assertEquals("Tue, 17 Sep 2019 11:48:05 UTC", ISO8601.DATETIME_UTC_COMPLETE.parse("2019-09-17T11:48:05Z").utc.toString())
+    }
+
+    @Test
+    fun testDateTimeUtcCompleteFraction() {
+        assertEquals("20190917T114805.000Z", ISO8601.DATETIME_UTC_COMPLETE_FRACTION.basic.format(1568720885000))
+        assertEquals("2019-09-17T11:48:05.000Z", ISO8601.DATETIME_UTC_COMPLETE_FRACTION.extended.format(1568720885000))
+
+        assertEquals("Tue, 17 Sep 2019 11:48:05 UTC", ISO8601.DATETIME_UTC_COMPLETE_FRACTION.parse("20190917T114805.000Z").utc.toString())
+        assertEquals("Tue, 17 Sep 2019 11:48:05 UTC", ISO8601.DATETIME_UTC_COMPLETE_FRACTION.parse("2019-09-17T11:48:05.000Z").utc.toString())
+    }
+
+    @Test
     fun testIssue84() {
         val badUtc = DateTime(
             date = Date(2020, 1, 4),

--- a/klock/src/commonTest/kotlin/com/soywiz/klock/internal/TimeZoneParserTest.kt
+++ b/klock/src/commonTest/kotlin/com/soywiz/klock/internal/TimeZoneParserTest.kt
@@ -1,0 +1,22 @@
+package com.soywiz.klock.internal
+
+import com.soywiz.klock.hours
+import com.soywiz.klock.minutes
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TimeZoneParserTest {
+    @Test
+    fun test() {
+        assertEquals(null, "TEST".tz)
+        assertEquals(0.hours, "Z".tz)
+        assertEquals(0.hours, "UTC".tz)
+        assertEquals(0.hours, "GMT".tz)
+        assertEquals((-7).hours, "PDT".tz)
+        assertEquals((-8).hours, "PST".tz)
+        assertEquals(2.hours + 30.minutes, "UTC+0230".tz)
+        assertEquals(-(2.hours + 30.minutes), "UTC-0230".tz)
+    }
+    private val String.tz get() = reader.readTimeZoneOffset()
+    private val String.reader get() = MicroStrReader(this)
+}


### PR DESCRIPTION
Applies https://github.com/korlibs/klock/pull/140 & fixes TimeZone reading

Co-Authored: @hardysim