### PR TITLE
expose PatternDateFormat regex string

### DIFF
--- a/klock/src/commonMain/kotlin/com/soywiz/klock/PatternDateFormat.kt
+++ b/klock/src/commonMain/kotlin/com/soywiz/klock/PatternDateFormat.kt
@@ -104,6 +104,9 @@ data class PatternDateFormat @JvmOverloads constructor(
         }
     }
 
+    /**
+     * @return the regular expression string used for matching this format, able to be composed into another regex
+     */
     fun matchingRegexString() = regexChunks.mapIndexed { index, it ->
         if (options.optionalSupport) {
             val opens = openOffsets.getOrElse(index) { 0 }

--- a/klock/src/commonMain/kotlin/com/soywiz/klock/PatternDateFormat.kt
+++ b/klock/src/commonMain/kotlin/com/soywiz/klock/PatternDateFormat.kt
@@ -104,8 +104,7 @@ data class PatternDateFormat @JvmOverloads constructor(
         }
     }
 
-    //val escapedFormat = Regex.escape(format)
-    internal val rx2: Regex = Regex("^" + regexChunks.mapIndexed { index, it ->
+    fun matchingRegexString() = regexChunks.mapIndexed { index, it ->
         if (options.optionalSupport) {
             val opens = openOffsets.getOrElse(index) { 0 }
             val closes = closeOffsets.getOrElse(index) { 0 }
@@ -117,7 +116,10 @@ data class PatternDateFormat @JvmOverloads constructor(
         } else {
             it
         }
-    }.joinToString("") + "$")
+    }.joinToString("")
+
+    //val escapedFormat = Regex.escape(format)
+    internal val rx2: Regex = Regex("^" + matchingRegexString() + "$")
 
 
     // EEE, dd MMM yyyy HH:mm:ss z -- > Sun, 06 Nov 1994 08:49:37 GMT

--- a/klock/src/commonTest/kotlin/com/soywiz/klock/DateTimeTest.kt
+++ b/klock/src/commonTest/kotlin/com/soywiz/klock/DateTimeTest.kt
@@ -475,4 +475,25 @@ class DateTimeTest {
         assertEquals(TimezoneOffset((-15).hours), DateFormat("z").parse("-15:00").offset)
         assertEquals(TimezoneOffset(0.hours), DateFormat("z").parse("+00:00").offset)
     }
+
+    @Test
+    fun testPatternFormatRegex() {
+        val dtmilli = 1536379689000L
+        assertEquals(dtmilli, DateTime(2018, 9, 8, 4, 8, 9).unixMillisLong)
+
+        val fmt = DateFormat("EEE, dd MMM yyyy HH:mm:ss z")
+        val msg = "[Sat, 08 Sep 2018 04:08:09 UTC]  Example log message"
+        val nomsg = "[Sat, 08 Sep 20G8 04:08:09 UTC]  Example log message" // 20G8
+
+        val logPattern = Regex("""^\[(""" + fmt.matchingRegexString() + """)]  """)
+
+        assertTrue(logPattern.containsMatchIn(msg), message = "correct datestamp should match")
+        assertFalse(logPattern.containsMatchIn(nomsg), message = "incorrect datestamp shouldn't match")
+
+        val match = logPattern.find(msg)
+        assertNotNull(match)
+
+        assertEquals(dtmilli, fmt.parseLong(match.groups[1]!!.value), message = "datestamp parsed from log line has correct value")
+        assertEquals("Example log message", msg.drop(match.value.length), message = "total match length for composed regex")
+    }
 }

--- a/klock/src/commonTest/kotlin/com/soywiz/klock/DateTimeTest.kt
+++ b/klock/src/commonTest/kotlin/com/soywiz/klock/DateTimeTest.kt
@@ -485,7 +485,7 @@ class DateTimeTest {
         val msg = "[Sat, 08 Sep 2018 04:08:09 UTC]  Example log message"
         val nomsg = "[Sat, 08 Sep 20G8 04:08:09 UTC]  Example log message" // 20G8
 
-        val logPattern = Regex("""^\[(""" + fmt.matchingRegexString() + """)]  """)
+        val logPattern = Regex("""^\[(""" + fmt.matchingRegexString() + """)\]  """)
 
         assertTrue(logPattern.containsMatchIn(msg), message = "correct datestamp should match")
         assertFalse(logPattern.containsMatchIn(nomsg), message = "incorrect datestamp shouldn't match")


### PR DESCRIPTION
This change will expose a regex string which matches the text of a correctly-formatted date, which can be composed into a larger regex.

It achieves this by taking an already existing part of the code for the internal regex rx2, and moving it into a function which is made public.

I need this change for a program which has to be able to match and extract timestamps in context.  This will allow the regex fragment matching the timestamp to be combined with regex fragments matching the expected strings around the timestamp, for efficiently locating candidate timestamps in a single regex search.