### PR TITLE
fix link to kotest matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,6 @@ dependencies {
 
 Kotest is a flexible and comprehensive testing tool for Kotlin with multiplatform support.
 It supports Klock adding additional matchers. For a full list of Klock Kotest matchers, check this link:
-<https://github.com/kotest/kotest/blob/master/doc/matchers.md>
+<https://kotest.io/docs/assertions/matchers.html>
 
 And you can find a sample here: <https://github.com/kotest/kotest/tree/master/kotest-assertions/kotest-assertions-klock>


### PR DESCRIPTION
It seems that the link to kotest matchers is moved.

Also, kotest sample is not found but I do not see where to link so I didn't fixed.

> And you can find a sample here: <https://github.com/kotest/kotest/tree/master/kotest-assertions/kotest-assertions-klock>